### PR TITLE
jQuery 1系が使用されていたのを修正。

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
+//= require jquery3
 //= require jquery_ujs
 //= require twitter/bootstrap
 //= require turbolinks


### PR DESCRIPTION
app/assets/javascripts/application.js を見るに jQuery の1系が使用されてたので3系を使う様に修正しました。
ランキングと応募が表示できる事、jQuery 3系が使われるようになった事だけ確認しています。

c.f. https://github.com/rails/jquery-rails#installation